### PR TITLE
Fix IntToStrEnh highlighting & add code folding support

### DIFF
--- a/osc-language-configuration.json
+++ b/osc-language-configuration.json
@@ -29,8 +29,9 @@
     },
     // Code folding
     "folding": {
-    "markers": {
-      "start": "{((macro|trigger):([\\w\\-+]+))|if|else}",
-      "end": "{(endif|end)}"
+        "markers": {
+            "start": "{((macro|trigger):([\\w\\-+]+))|if|else}",
+            "end": "{(endif|end)}"
+      }
     }
 }

--- a/osc-language-configuration.json
+++ b/osc-language-configuration.json
@@ -26,5 +26,11 @@
     "indentationRules": {
         "increaseIndentPattern": "{(init|frame|frame_ai|if|else|(macro|trigger):([\\w\\-+]+))}",
         "decreaseIndentPattern": "{(end|endif)}"
+    },
+    // Code folding
+    "folding": {
+    "markers": {
+      "start": "{((macro|trigger):([\\w\\-+]+))|if|else}",
+      "end": "{(endif|end)}"
     }
 }

--- a/osc-language-configuration.json
+++ b/osc-language-configuration.json
@@ -30,7 +30,7 @@
     // Code folding
     "folding": {
         "markers": {
-            "start": "{((macro|trigger):([\\w\\-+]+))|if|else}",
+            "start": "{(init|frame|frame_ai|if|else|(macro|trigger):([\\w\\-+]+))}",
             "end": "{(endif|end)}"
       }
     }

--- a/syntaxes/omsiscript.tmLanguage.json
+++ b/syntaxes/omsiscript.tmLanguage.json
@@ -214,7 +214,7 @@
 		},
 		"string-operators": {
 			"name": "keyword.operator.string.omsi.script",
-			"match": "\\$(?:\\+|\\*|length|cutBegin|cutEnd|SetLengthR|SetLengthC|SetLengthL|IntToStr|IntToStrEnh|StrToFloat|RemoveSpaces)"
+			"match": "\\$(?:\\+|\\*|length|cutBegin|cutEnd|SetLengthR|SetLengthC|SetLengthL|IntToStrEnh|IntToStr|StrToFloat|RemoveSpaces)"
 		},
 		"comment": {
 			"name": "comment.line.quote.omsi.script",


### PR DESCRIPTION
Hey there, thanks for this neat little extension :)

Just a quick little syntax highlighting fix here, in VSCode `Enh` was not being highlighted properly before.

For the code folding, it works fine, however even without this support added to the files, VSCode seems to automatically suggest folding for some comments (usually only if they have special chars) and it skips some if statements (rarely). I don't see a setting to disable this anywhere. Pretty sure this isn't a regex issue for the above reason, but I might be wrong. I also tried excluding comment characters from folding via regex but it didn't do anything, even though it was completely valid simple regex