### PR TITLE
Add System Variable snippets + Seperate Syntax Highlighting

### DIFF
--- a/snippets/omsicfg.json
+++ b/snippets/omsicfg.json
@@ -377,6 +377,44 @@
         ],
         "description": "Sets texture translation by given axis (X or Y) by given value."
     },
+    "Texchanges": {
+        "prefix": ["texchanges", "[texchanges]"],
+        "body": [
+            "[texchanges]",
+            "${1:path\\to\\a\\file.cfg}",
+            "",
+            "$0"
+        ],
+        "description": "Defines a cfg file that deals with texture changes to a mesh"
+    },
+    "Smoke": {
+        "prefix": ["smoke", "[smoke]"],
+        "body": [
+            "[smoke]",
+            "${1:pos_x}",
+            "${2:pos_y}",
+            "${3:pos_z}",
+            "${4:dir_x}",
+            "${5:dir_y}",
+            "${6:dir_z}",
+            "${7:Velocity variable}",
+            "${8:Speed Variation}",
+            "${9:Frequency variable}",
+            "${10:Lifespan variable}",
+            "${11:Brake Factor}",
+            "${12:Coefficent}",
+            "${13:Start size}",
+            "${14:Magnification rate}",
+            "${15:Initial alpha variable}",
+            "${16:Alpha variation}",
+            "${17:R}",
+            "${18:G}",
+            "${19:B}",
+            "",
+            "$0"
+        ],
+        "description": "Defines a perticle effect within a vehicle (usually exhaust smoke)"
+    },
     "Use text texture": {
         "prefix": ["useTextTexture", "[useTextTexture]"],
         "body": [
@@ -385,6 +423,37 @@
             "",
             "$0"
         ]
+    },
+    "Use script texture": {
+        "prefix": ["useScriptTexture", "[useScriptTexture]"],
+        "body": [
+            "[useScriptTexture]",
+            "${1:index}",
+            "",
+            "$0"
+        ]
+    },
+    "Texture Change Master Definition": {
+        "prefix": ["newtexchangemaster", "[newtexchangemaster]"],
+        "body": [
+            "[newtexchangemaster]",
+            "${1:texture}",
+            "${2:variable}",
+            "",
+            "$0"
+        ],
+        "description": "Defines a new texture change in a cfg defined under a \"texchanges\" tag"
+    },
+    "Texture Change Entries": {
+        "prefix": ["entries", "[entries]"],
+        "body": [
+            "[entries]",
+            "${1:amount}",
+            "${2:image.bmp}",
+            "",
+            "$0"
+        ],
+        "description": "Defines a new texture change in a cfg defined under a \"texchanges\" tag"
     },
     "AIList group": {
         "prefix": ["aigroup_2", "[aigroup_2]"],

--- a/snippets/omsicfg.json
+++ b/snippets/omsicfg.json
@@ -240,6 +240,7 @@
     "Material allcolor": {
         "prefix": ["matl_allcolor", "[matl_allcolor]"],
         "body": [
+            "[matl_allcolor]",
             "${1:Diffuse (R)}",
             "${2:Diffuse (G)}",
             "${3:Diffuse (B)}",

--- a/snippets/omsiscript.json
+++ b/snippets/omsiscript.json
@@ -43,7 +43,7 @@
     },
     "Load system": {
         "prefix": ["load-system"],
-        "body": "(L.S.${1|Timegap,GetTime,NoSound,Pause,Time,Day,Month,Year,DayOfYear,mouse_x,mouse_y,PrecipType,PrecipRate,coll_pos_x,coll_pos_y,coll_pos_z,coll_energy,Weather_Temperature,Weather_AbsHum,wearlifespan,AutoClutch,SunAlt|})"
+        "body": "(L.S.${1|Timegap,GetTime,NoSound,Pause,Time,Day,Month,Year,DayOfYear,mouse_x,mouse_y,coll_pos_x,coll_pos_y,coll_pos_z,coll_energy,Weather_Temperature,Weather_AbsHum,AutoClutch,SunAlt|})"
     },
     "Load string": {
         "prefix": ["load-string"],

--- a/snippets/omsiscript.json
+++ b/snippets/omsiscript.json
@@ -41,6 +41,10 @@
         "prefix": ["save-local"],
         "body": "(S.L.${1:variable})"
     },
+    "Load system": {
+        "prefix": ["load-system"],
+        "body": "(L.S.${1|Timegap,GetTime,NoSound,Pause,Time,Day,Month,Year,DayOfYear,mouse_x,mouse_y,PrecipType,PrecipRate,coll_pos_x,coll_pos_y,coll_pos_z,coll_energy,Weather_Temperature,Weather_AbsHum,wearlifespan,AutoClutch,SunAlt|})"
+    },
     "Load string": {
         "prefix": ["load-string"],
         "body": "(L.$.${1:variable})"

--- a/syntaxes/omsiscript.tmLanguage.json
+++ b/syntaxes/omsiscript.tmLanguage.json
@@ -125,7 +125,7 @@
         },
         "system-variable": {
             "name": "meta.omsi.script",
-            "match": "\\(L\\.[LS]\\.([Tt]ime[Gg]ap|[Gg]et[Tt]ime|NoSound|Pause|Time|Day(?:|OfYear)|Month|Year|mouse_[xy]|coll_(?:energy|pos_[xyz])|Weather_(?:Temperature|AbsHum)|AutoClutch|SunAlt)\\)",
+            "match": "\\(L\\.S\\.([Tt]ime[Gg]ap|[Gg]et[Tt]ime|NoSound|Pause|Time|Day(?:|OfYear)|Month|Year|mouse_[xy]|coll_(?:energy|pos_[xyz])|Weather_(?:Temperature|AbsHum)|AutoClutch|SunAlt)\\)",
             "captures": {
                 "1": {
                     "name": "storage.constant.omsi.script"

--- a/syntaxes/omsiscript.tmLanguage.json
+++ b/syntaxes/omsiscript.tmLanguage.json
@@ -89,6 +89,9 @@
                     "include": "#load-store-variable"
                 },
                 {
+                    "include": "#system-variable"
+                },
+                {
                     "include": "#load-constant"
                 },
                 {
@@ -113,10 +116,19 @@
         },
         "load-store-variable": {
             "name": "meta.omsi.script",
-            "match": "\\([LS]\\.[LS\\$]\\.([\\w\\-+]+)\\)",
+            "match": "\\([LS]\\.[L\\$]\\.([\\w\\-+]+)\\)",
             "captures": {
                 "1": {
                     "name": "variable.omsi.script"
+                }
+            }
+        },
+        "system-variable": {
+            "name": "meta.omsi.script",
+            "match": "\\(L\\.[LS]\\.([Tt]ime[Gg]ap|[Gg]et[Tt]ime|NoSound|Pause|Time|Day(?:|OfYear)|Month|Year|mouse_[xy]|coll_(?:energy|pos_[xyz])|Weather_(?:Temperature|AbsHum)|AutoClutch|SunAlt)\\)",
+            "captures": {
+                "1": {
+                    "name": "storage.constant.omsi.script"
                 }
             }
         },


### PR DESCRIPTION
### Additions
- Add Snippets and seperate syntax highlighting for System variables
  - `PrecipType`, `PrecipRate` and `wearlifespan` aren't included as these are local variables, for some reason, even though they are in `varlist_system.txt`
- Add a few cfg snippets
  - `useScriptTexture`, seen on some French DLC buses
  - `smoke`, used on pretty much all buses
  - Rollband specific ones, like `texchanges` and associated cfg with it

### Fixes
- Fix missing `matl_allcolor` tag definition